### PR TITLE
Update location.sh

### DIFF
--- a/modules/location/scripts/location.sh
+++ b/modules/location/scripts/location.sh
@@ -44,7 +44,7 @@ n=0
 path_out=""
 until [ "$n" -ge 5 ]
 do
-   path_out=`ibmcloud sat host attach --location $LOCATION -l $LABEL` && break
+   path_out=`ibmcloud sat host attach --location $LOCATION -hl $LABEL` && break
    echo "************* Failed with $n, waiting to retry *****************"
    n=$((n+1))
    sleep 10


### PR DESCRIPTION
Host attach label param is now `-hl`

Note: it seems like it might still be `-l` on prod for the time being. 