### PR TITLE
Add TF_VERSION to azure variables.tf

### DIFF
--- a/examples/satellite-azure/variables.tf
+++ b/examples/satellite-azure/variables.tf
@@ -3,6 +3,12 @@
 # # Azure and IBM Authentication Variables
 # ##################################################
 
+variable "TF_VERSION" {
+  description = "terraform version"
+  type = string
+  default = "0.13"
+}
+
 variable "subscription_id" {
   description = "Subscription id of Azure Account"
   type        = string


### PR DESCRIPTION
add TF_VERSION to azure variables.tf and default it to 0.13, for use with schematics.