### PR TITLE
remove instance type restrictions for AWS

### DIFF
--- a/.github/workflows/validate_terraform.yml
+++ b/.github/workflows/validate_terraform.yml
@@ -21,7 +21,7 @@ jobs:
         name: setup terraform
         uses: hashicorp/setup-terraform@v1  # sets up Terraform CLI in your GitHub Actions workflow
         with:
-          terraform_version: 0.13.0
+          terraform_version: 0.13.1
       -
         name: Install pre-commit
         run: pip install pre-commit

--- a/examples/satellite-aws/README.md
+++ b/examples/satellite-aws/README.md
@@ -133,7 +133,7 @@ module "satellite-host" {
 | host_provider                         | The cloud provider of host/vms.                                   | string   | aws     | no       |
 | satellite_host_count                  | The total number of aws host to create for control plane. satellite_host_count value should always be in multiples of 3, such as 3, 6, 9, or 12 hosts   | number   | 3 |  yes     |
 | addl_host_count                       | The total number of additional aws host                            | number   | 0 |  yes     |
-| instance_type                         | The type of aws instance to start, satellite only accepts `m5d.2xlarge` or `m5d.4xlarge` as instance type.     | string   | m5d.2xlarge     | yes |
+| instance_type                         | The type of aws instance to create.     | string   | m5d.xlarge     | yes |
 | ssh_public_key                        | SSH Public Key. Get your ssh key by running `ssh-key-gen` command | string   | n/a     | no |
 | resource_prefix                       | Name to be used on all aws resources as prefix                        | string   | satellite-aws     | yes |
 

--- a/examples/satellite-aws/variables.tf
+++ b/examples/satellite-aws/variables.tf
@@ -113,14 +113,9 @@ variable "addl_host_count" {
 }
 
 variable "instance_type" {
-  description = "The type of aws instance to start, satellite only accepts `m5d.xlarge`, `m5d.2xlarge`, or `m5d.4xlarge` as an instance type."
+  description = "The type of aws instance to create"
   type        = string
   default     = "m5d.xlarge"
-
-  validation {
-    condition     = var.instance_type == "m5d.xlarge" || var.instance_type == "m5d.2xlarge" || var.instance_type == "m5d.4xlarge"
-    error_message = "Sorry, satellite only accepts m5d.xlarge, m5d.2xlarge, or m5d.4xlarge as an instance type."
-  }
 }
 
 variable "ssh_public_key" {


### PR DESCRIPTION
- Don't restrict aws instance types.
- Update readme to correct default.