### PR TITLE
Azure multi-host support

### DIFF
--- a/examples/satellite-aws/README.md
+++ b/examples/satellite-aws/README.md
@@ -131,9 +131,11 @@ module "satellite-host" {
 | labels                                | Add labels to attach host script                                  | list     | [env:prod]  | no   |
 | location_bucket                       | COS bucket name                                                   | string   | n/a     | no       |
 | host_provider                         | The cloud provider of host/vms.                                   | string   | aws     | no       |
-| satellite_host_count                  | The total number of aws host to create for control plane. satellite_host_count value should always be in multiples of 3, such as 3, 6, 9, or 12 hosts   | number   | 3 |  yes     |
-| addl_host_count                       | The total number of additional aws host                            | number   | 0 |  yes     |
-| instance_type                         | The type of aws instance to create.     | string   | m5d.xlarge     | yes |
+| satellite_host_count                  | [Deprecated] The total number of aws host to create for control plane. satellite_host_count value should always be in multiples of 3, such as 3, 6, 9, or 12 hosts   | number   | 3 |  yes     |
+| addl_host_count                       | [Deprecated] The total number of additional aws host                            | number   | 0 |  yes     |
+| instance_type                         | [Deprecated] The type of aws instance to create.     | string   | m5d.xlarge     | yes |
+| cp_hosts                              | A list of AWS host objects used to create the location control plane, including parameters instance_type and count. Control plane count values should always be in multipes of 3, such as 3, 6, 9, or 12 hosts.                  | list   | [<br>&ensp; {<br>&ensp;&ensp; instance_type = "m5d.xlarge"<br>&ensp; count         = 3<br>&ensp;&ensp; }<br>]             | yes    |
+| addl_hosts                            | A list of AWS host objects used for provisioning services on your location after setup, including instance_type and count, see cp_hosts for an example.                  | list   | []             | yes    |
 | ssh_public_key                        | SSH Public Key. Get your ssh key by running `ssh-key-gen` command | string   | n/a     | no |
 | resource_prefix                       | Name to be used on all aws resources as prefix                        | string   | satellite-aws     | yes |
 

--- a/examples/satellite-azure/README.md
+++ b/examples/satellite-azure/README.md
@@ -140,19 +140,21 @@ module "satellite-host" {
 | tenant_id                             | Tenent id of Azure Account                                        | string   | n/a     | yes   |
 | client_secret                         | Client Secret of Azure Account                                    | string   | n/a     | yes      |
 | is_az_resource_group_exist            | "If false, resource group (az_resource_group) will be created. If true, existing resource group (az_resource_group) will be read"| bool   | false  | yes   |
-| az_resource_group                     | Azure Resource Group                                              | string  | satellite-azure  | yes   |
-| az_region                             | Azure Region                                                      | string   | eastus  | yes   |
-| location                              | Name of the Location that has to be created                       | string   | satellite-azure | yes   |
-| is_location_exist                     | Determines if the location has to be created or not               | bool     | false   | yes      |
-| managed_from                          | The IBM Cloud region to manage your Satellite location from.      | string   | wdc   | yes      |
+| az_resource_group                     | Azure Resource Group                                              | string   | satellite-azure  | yes   |
+| az_region                             | Azure Region                                                      | string   | eastus           | yes   |
+| location                              | Name of the Location that has to be created                       | string   | satellite-azure  | yes   |
+| is_location_exist                     | Determines if the location has to be created or not               | bool     | false            | yes   |
+| managed_from                          | The IBM Cloud region to manage your Satellite location from.      | string   | wdc              | yes   |
 | location_zones                        | Allocate your hosts across three zones for higher availablity     | list     | ["us-east-1", "us-east-2", "us-east-3"]    | yes      |
-| host_labels                                | Add labels to attach host script                                  | list     | [env:prod]  | no   |
-| location_bucket                       | COS bucket name                                                   | string   | n/a     | no       |
-| az_resource_prefix                       | Name to be used on all azure resources as prefix                        | string   | satellite-azure     | yes |
-| satellite_host_count                  | The total number of azure host to create for control plane. satellite_host_count value should always be in multiples of 3, such as 3, 6, 9, or 12 hosts                 | number   | 3 |  yes     |
-| addl_host_count                       | The total number of additional azure host                            | number   | 0 |  yes     |
-|instance_type|The type of azure instance to start|string|Standard_D4s_v3|yes|
-| ssh_public_key                        | SSH Public Key. Get your ssh key by running `ssh-key-gen` command | string   | n/a     | no |
+| host_labels                           | Add labels to attach host script                                  | list     | [env:prod]       | no    |
+| location_bucket                       | COS bucket name                                                   | string   | n/a              | no    |
+| az_resource_prefix                    | Name to be used on all azure resources as prefix                  | string   | satellite-azure  | yes   |
+| satellite_host_count                  | [Deprecated] The total number of azure host to create for control plane. satellite_host_count value should always be in multiples of 3, such as 3, 6, 9, or 12 hosts                 | number   | null |  no     |
+| addl_host_count                       | [Deprecated] The total number of additional azure host            | number   | null             | no    |
+| instance_type                         | [Deprecated] The type of azure instance to start                  | string   | null             | no    |
+| cp_hosts                              | A list of Azure host objects used to create the location control plane, including parameters instance_type and count. Control plane count values should always be in multipes of 3, such as 3, 6, 9, or 12 hosts.                  | list   | [<br>&ensp; {<br>&ensp;&ensp; instance_type = "Standard_D4as_v4"<br>&ensp; count         = 3<br>&ensp;&ensp; }<br>]             | yes    |
+| addl_hosts                            | A list of Azure host objects used for provisioning services on your location after setup, including instance_type and count, see cp_hosts for an example.                  | list   | []             | yes    |
+| ssh_public_key                        | SSH Public Key. Get your ssh key by running `ssh-key-gen` command | string   | n/a              | no    |
 
 
 ## Outputs

--- a/examples/satellite-azure/host.tf
+++ b/examples/satellite-azure/host.tf
@@ -7,11 +7,18 @@ module "satellite-host" {
   //Uncomment following line to point the source to registry level module
   //source = "terraform-ibm-modules/satellite/ibm//modules/host"
 
-  depends_on     = [azurerm_virtual_machine_data_disk_attachment.disk_attach]
-  source         = "../../modules/host"
-  host_count     = var.satellite_host_count
-  location       = module.satellite-location.location_id
-  host_vms       = azurerm_linux_virtual_machine.az_host.*.name
+  for_each = local.hosts
+
+  depends_on = [azurerm_virtual_machine_data_disk_attachment.disk_attach]
+  source     = "../../modules/host"
+  host_count = each.value.for_control_plane ? each.value.count : 0
+  location   = module.satellite-location.location_id
+  host_vms = [for count_index in range(
+    sum([for index, host in local.hosts : index < each.key ? host.count : 0]), // starting ID
+    sum([for index, host in local.hosts : index <= each.key ? host.count : 0]) // starting ID + current IDs count
+    ) :
+    azurerm_linux_virtual_machine.az_host[count_index].name
+  ]
   location_zones = var.location_zones
   host_labels    = var.host_labels
   host_provider  = "azure"

--- a/examples/satellite-azure/locals.tf
+++ b/examples/satellite-azure/locals.tf
@@ -1,0 +1,42 @@
+locals {
+  zones = [1, 2, 3]
+
+  # combine cp_hosts and addl_hosts into a map so we can use for_each later
+  # support backwards compatibility with providing var.instance_type, satellite_host_count, and addl_host_count
+  hosts = (var.satellite_host_count != null && var.addl_host_count != null && var.instance_type != null) ? {
+    0 = {
+      instance_type     = var.instance_type
+      count             = var.satellite_host_count
+      for_control_plane = true
+    }
+    1 = {
+      instance_type     = var.instance_type
+      count             = var.addl_host_count
+      for_control_plane = false
+    }
+    } : merge({
+      for i, host in var.cp_hosts :
+      i => {
+        instance_type     = host.instance_type
+        count             = host.count
+        for_control_plane = true
+      }
+      }, {
+      for i, host in var.addl_hosts :
+      sum([i, length(var.cp_hosts)]) => {
+        instance_type     = host.instance_type
+        count             = host.count
+        for_control_plane = false
+      }
+  })
+  // convert hosts to be a flat object with one key per desired host
+  hosts_flattened = { for index, item in flatten([
+    for host_index, host in local.hosts : [
+      for count_index in range(0, host.count) : {
+        instance_type     = host.instance_type
+        for_control_plane = host.for_control_plane
+        zone              = element(local.zones, count_index)
+      }
+    ]
+  ]) : index => item }
+}

--- a/examples/satellite-azure/outputs.tf
+++ b/examples/satellite-azure/outputs.tf
@@ -2,5 +2,5 @@ output "location_id" {
   value = module.satellite-location.location_id
 }
 output "host_ids" {
-  value = azurerm_linux_virtual_machine.az_host.*.id
+  value = azurerm_linux_virtual_machine.az_host
 }

--- a/examples/satellite-azure/outputs.tf
+++ b/examples/satellite-azure/outputs.tf
@@ -2,5 +2,5 @@ output "location_id" {
   value = module.satellite-location.location_id
 }
 output "host_ids" {
-  value = azurerm_linux_virtual_machine.az_host
+  value = [for host in azurerm_linux_virtual_machine.az_host : host.id]
 }

--- a/examples/satellite-azure/variables.tf
+++ b/examples/satellite-azure/variables.tf
@@ -138,10 +138,6 @@ variable "addl_hosts" {
     error_message = "Each object should have an instance_type."
   }
 
-  validation {
-    condition     = ! contains([for host in var.addl_hosts : (host.count % 3 == 0)], false)
-    error_message = "Count value for all hosts should always be in multiples of 3, such as 6, 9, or 12 hosts."
-  }
 }
 
 # ##################################################

--- a/examples/satellite-azure/variables.tf
+++ b/examples/satellite-azure/variables.tf
@@ -56,7 +56,7 @@ variable "ibm_resource_group" {
 # ##################################################
 
 variable "az_resource_prefix" {
-  description = "Name to be used on all azure resources as prefix"
+  description = "Name to be used on all Azure resources as prefix"
   type        = string
   default     = "satellite-azure"
 }
@@ -66,23 +66,82 @@ variable "ssh_public_key" {
   default     = null
 }
 variable "instance_type" {
-  description = "The type of azure instance to start"
+  description = "The type of Azure instance to start"
   type        = string
-  default     = "Standard_D4s_v3"
+  default     = null
 }
 variable "satellite_host_count" {
   description = "The total number of Azure host to create for control plane. "
   type        = number
-  default     = 3
+  default     = null
   validation {
-    condition     = (var.satellite_host_count % 3) == 0 && var.satellite_host_count > 0
+    condition     = var.satellite_host_count == null || ((can((var.satellite_host_count % 3) == 0)) && can(var.satellite_host_count > 0))
     error_message = "Sorry, host_count value should always be in multiples of 3, such as 6, 9, or 12 hosts."
   }
 }
 variable "addl_host_count" {
-  description = "The total number of additional azure vm's"
+  description = "The total number of additional Azure vms"
   type        = number
-  default     = 0
+  default     = null
+}
+
+variable "cp_hosts" {
+  description = "A map of Azure host objects used to create the location control plane, including instance_type and count. Control plane count value should always be in multiples of 3, such as 3, 6, 9, or 12 hosts."
+  type = list(
+    object(
+      {
+        instance_type = string
+        count         = number
+      }
+    )
+  )
+  default = [
+    {
+      instance_type = "Standard_D4as_v4"
+      count         = 3
+    }
+  ]
+
+  validation {
+    condition     = ! contains([for host in var.cp_hosts : (host.count > 0)], false)
+    error_message = "All hosts must have a count of at least 1."
+  }
+  validation {
+    condition     = ! contains([for host in var.cp_hosts : (host.count % 3 == 0)], false)
+    error_message = "Count value for all hosts should always be in multiples of 3, such as 6, 9, or 12 hosts."
+  }
+
+  validation {
+    condition     = can([for host in var.cp_hosts : host.instance_type])
+    error_message = "Each object should have an instance_type."
+  }
+}
+
+variable "addl_hosts" {
+  description = "A list of Azure host objects used for provisioning services on your location after setup, including instance_type and count."
+  type = list(
+    object(
+      {
+        instance_type = string
+        count         = number
+      }
+    )
+  )
+  default = []
+  validation {
+    condition     = ! contains([for host in var.addl_hosts : (host.count > 0)], false)
+    error_message = "All hosts must have a count of at least 1."
+  }
+
+  validation {
+    condition     = can([for host in var.addl_hosts : host.instance_type])
+    error_message = "Each object should have an instance_type."
+  }
+
+  validation {
+    condition     = ! contains([for host in var.addl_hosts : (host.count % 3 == 0)], false)
+    error_message = "Count value for all hosts should always be in multiples of 3, such as 6, 9, or 12 hosts."
+  }
 }
 
 # ##################################################


### PR DESCRIPTION
Add variables options for specifying multiple types of hosts. Similar to the AWS one, tested with supplying both the following
```
# addl_host_count = 3
# satellite_host_count = 3
# instance_type = "Standard_D4as_v4"
cp_hosts = [
  {
    count         = 3
    instance_type = "Standard_D4as_v4"
  },
  {
    count         = 6
    instance_type = "Standard_D4s_v4"
  }
]
addl_hosts = [
  {
    count         = 3
    instance_type = "Standard_D4as_v4"
  }
]
```

After speaking with @jsloyer we should be enforcing multiples of 3 service hosts, not just control plane.