### PR TITLE
Add regex for prefix

### DIFF
--- a/examples/satellite-azure/variables.tf
+++ b/examples/satellite-azure/variables.tf
@@ -59,6 +59,10 @@ variable "az_resource_prefix" {
   description = "Name to be used on all azure resources as prefix"
   type        = string
   default     = "satellite-azure"
+  validation {
+    condition     = can(regex("^[a-z0-9-]+$", var.az_resource_prefix))
+    error_message = "Variable az_resource_prefix should always be lowercase alphanumeric, and may contain hyphens."
+  }
 }
 variable "ssh_public_key" {
   description = "SSH Public Key. Get your ssh key by running `ssh-key-gen` command"

--- a/examples/satellite-gcp/variables.tf
+++ b/examples/satellite-gcp/variables.tf
@@ -36,8 +36,8 @@ variable "gcp_resource_prefix" {
   default     = "satellite-google"
 
   validation {
-    condition     = var.gcp_resource_prefix != "" && length(var.gcp_resource_prefix) <= 25
-    error_message = "Sorry, please provide value for resource_prefix variable or check the length of resource_prefix it should be less than 25 chars."
+    condition     = can(regex("^[a-z0-9-]{1,25}$", var.gcp_resource_prefix))
+    error_message = "Sorry, gcp_resource_prefix must be between 1 and 25 characters, contain lowercase characters, numbers, or hyphens."
   }
 }
 variable "satellite_host_count" {

--- a/examples/satellite-gcp/variables.tf
+++ b/examples/satellite-gcp/variables.tf
@@ -36,8 +36,8 @@ variable "gcp_resource_prefix" {
   default     = "satellite-google"
 
   validation {
-    condition     = can(regex("^[a-z0-9-]{1,25}$", var.gcp_resource_prefix))
-    error_message = "Sorry, gcp_resource_prefix must be between 1 and 25 characters, contain lowercase characters, numbers, or hyphens."
+    condition     = can(regex("^[a-zA-Z0-9-]{1,25}$", var.gcp_resource_prefix))
+    error_message = "Sorry, gcp_resource_prefix must be between 1 and 25 characters, contain uppercase or lowercase characters, numbers, or hyphens."
   }
 }
 variable "satellite_host_count" {


### PR DESCRIPTION
Don't allow capital letters or periods in prefix for azure
Azure doesn't like capitals, and at host assign, the passed host ID does a split on ".". For GCP and Azure resource prefix gets used for host ID, as a result a split occurs on the prefix ex.
```
prefix = "satellite.azure"

host ID = split(".", ["satellite.azure-vm-1", "satellite.azure-vm-2", "satellite.azure-vm-3"]) // result is [satellite, satellite, satellite]