### PR TITLE
Support creating multiple host types with a single terraform for GCP

### DIFF
--- a/examples/satellite-azure/variables.tf
+++ b/examples/satellite-azure/variables.tf
@@ -141,7 +141,6 @@ variable "addl_hosts" {
     condition     = can([for host in var.addl_hosts : host.instance_type])
     error_message = "Each object should have an instance_type."
   }
-
 }
 
 # ##################################################

--- a/examples/satellite-gcp/README.md
+++ b/examples/satellite-gcp/README.md
@@ -158,9 +158,11 @@ module "satellite-host" {
 | host_labels                                | Add labels to attach host script                                  | list     | [env:prod]  | no   |
 | location_bucket                       | COS bucket name                                                   | string   | n/a     | no       |
 | gcp_resource_prefix                       | Name to be used on all google resources as prefix                        | string   | satellite-google     | yes |
-| satellite_host_count                  | The total number of google hosts to create for control plane. satellite_host_count value should always be in multiples of 3, such as 3, 6, 9, or 12 hosts | number   | 3 |  yes     |
-| addl_host_count                       | The total number of additional google hosts                          | number   | 0 |  no    |
-|instance_type|The type of google instance to start|string|`"n2-standard-4"`|yes|
+| satellite_host_count                  | [Deprecated] The total number of google host to create for control plane. satellite_host_count value should always be in multiples of 3, such as 3, 6, 9, or 12 hosts                 | number   | null |  no     |
+| addl_host_count                       | [Deprecated] The total number of additional google host            | number   | null             | no    |
+| instance_type                         | [Deprecated] The type of google instance to start                  | string   | null             | no    |
+| cp_hosts                              | A list of GCP host objects used to create the location control plane, including parameters instance_type and count. Control plane count values should always be in multipes of 3, such as 3, 6, 9, or 12 hosts.                  | list   | [<br>&ensp; {<br>&ensp;&ensp; instance_type = "n2-standard-4"<br>&ensp; count         = 3<br>&ensp;&ensp; }<br>]             | yes    |
+| addl_hosts                            | A list of GCP host objects used for provisioning services on your location after setup, including instance_type and count, see cp_hosts for an example.                  | list   | []             | yes    |
 | ssh_public_key                        | SSH Public Key. Get your ssh key by running `ssh-key-gen` command | string   | n/a     | no |
 | gcp_ssh_user                        | "SSH User of above provided ssh_public_key" | string   | n/a     | no |
 

--- a/examples/satellite-gcp/host.tf
+++ b/examples/satellite-gcp/host.tf
@@ -1,14 +1,12 @@
 module "satellite-host" {
+  for_each = local.hosts
+
   depends_on     = [module.gcp_hosts]
   source         = "../../modules/host"
-  host_count     = var.satellite_host_count
+  host_count     = each.value.for_control_plane ? each.value.count : 0
   location       = module.satellite-location.location_id
-  host_vms       = local.hosts
+  host_vms       = [for instance in module.gcp_hosts[each.key].instances_details : instance.name]
   location_zones = var.location_zones
   host_labels    = var.host_labels
   host_provider  = "google"
-}
-
-locals {
-  hosts = [for instance in module.gcp_hosts.instances_details : instance.name]
 }

--- a/examples/satellite-gcp/instance.tf
+++ b/examples/satellite-gcp/instance.tf
@@ -144,7 +144,7 @@ module "gcp_hosts" {
   subnetwork_project = var.gcp_project
   subnetwork         = module.gcp_subnets.subnets["${var.gcp_region}/${var.gcp_resource_prefix}-subnet"].self_link
   num_instances      = each.value.count
-  hostname           = "${var.gcp_resource_prefix}-host"
+  hostname           = "${var.gcp_resource_prefix}-host-${each.key}"
   instance_template  = module.gcp_host-template[each.key].self_link
   access_config = [{
     nat_ip       = null

--- a/examples/satellite-gcp/locals.tf
+++ b/examples/satellite-gcp/locals.tf
@@ -1,0 +1,30 @@
+locals {
+  # combine cp_hosts and addl_hosts into a map so we can use for_each later
+  # support backwards compatibility with providing var.instance_type, satellite_host_count, and addl_host_count
+  hosts = (var.satellite_host_count != null && var.addl_host_count != null && var.instance_type != null) ? {
+    0 = {
+      instance_type     = var.instance_type
+      count             = var.satellite_host_count
+      for_control_plane = true
+    }
+    1 = {
+      instance_type     = var.instance_type
+      count             = var.addl_host_count
+      for_control_plane = false
+    }
+    } : merge({
+      for i, host in var.cp_hosts :
+      i => {
+        instance_type     = host.instance_type
+        count             = host.count
+        for_control_plane = true
+      }
+      }, {
+      for i, host in var.addl_hosts :
+      sum([i, length(var.cp_hosts)]) => {
+        instance_type     = host.instance_type
+        count             = host.count
+        for_control_plane = false
+      }
+  })
+}

--- a/examples/satellite-gcp/outputs.tf
+++ b/examples/satellite-gcp/outputs.tf
@@ -2,8 +2,8 @@ output "location_id" {
   value = module.satellite-location.location_id
 }
 output "gcp_host_links" {
-  value = module.gcp_hosts.instances_self_links
+  value = [for host in module.gcp_hosts : host.instances_self_links]
 }
 output "gcp_host_names" {
-  value = local.hosts
+  value = flatten([for host in module.gcp_hosts : [for instance in host.instances_details : instance.name]])
 }


### PR DESCRIPTION
Add variables options for specifying multiple types of hosts. Similar to the AWS and azure one, tested with supplying both the following
```
# addl_host_count = 3
# satellite_host_count = 3
# instance_type = "n2-standard-4"
cp_hosts = [
  {
    count         = 3
    instance_type = "n2-standard-4"
  },
  {
    count         = 6
    instance_type = "n2-standard-8"
  }
]
addl_hosts = [
  {
    count         = 3
    instance_type = "n2-standard-4"
  }
]
```