### PR TITLE
azure - ocp version, default create_cluster false

### DIFF
--- a/examples/satellite-azure/variables.tf
+++ b/examples/satellite-azure/variables.tf
@@ -196,7 +196,7 @@ variable "host_labels" {
 variable "create_cluster" {
   description = "Create Cluster: Disable this, not to provision cluster"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "cluster" {
@@ -212,7 +212,7 @@ variable "cluster" {
 
 variable "kube_version" {
   description = "Satellite Kube Version"
-  default     = "4.10.9_openshift"
+  default     = "4.10_openshift"
 }
 
 variable "worker_count" {


### PR DESCRIPTION
- when passing in kube_version, don't pass in the patch level. That is automatically chosen for you. As it was, the patch level specified was old, so deploy would fail.
- set `create_cluster` default to `false`. This is what we wanted but it got lost in the shuffle of the previous PR.

