### PR TITLE
Add image selection for all providers

### DIFF
--- a/examples/satellite-azure/README.md
+++ b/examples/satellite-azure/README.md
@@ -178,6 +178,8 @@ module "satellite-host" {
 | addl_hosts                            | A list of Azure host objects used for provisioning services on your location after setup, including instance_type and count, see cp_hosts for an example.                  | list   | []             | yes    |
 | ssh_public_key                        | SSH Public Key. Get your ssh key by running `ssh-key-gen` command | string   | n/a              | no    |
 | cluster_profile                       | Profile information of cluster hosts                              | string   | mx2-8x64| no       |
+| worker_image_sku                      | Specify the image sku for hosts to be created with                    | string   | 7-LVM    | no       |
+| worker_image_version                  | Specify the image version for hosts to be created with                    | string   | latest   | no       |
 | create_cluster                        | Create cluster Disable this, not to provision cluster             | bool     | false    | no       |
 | cluster                               | Name of the ROKS Cluster that has to be created                   | string   | satellite-azure-cluster     | no      |
 | zones                         | Allocate your hosts across these three zones                      | set      | n/a     | no      |

--- a/examples/satellite-azure/instance.tf
+++ b/examples/satellite-azure/instance.tf
@@ -135,8 +135,8 @@ resource "azurerm_linux_virtual_machine" "az_host" {
   source_image_reference {
     publisher = "RedHat"
     offer     = "RHEL"
-    sku       = "7-LVM"
-    version   = "latest"
+    sku       = var.worker_image_sku
+    version   = var.worker_image_version
   }
 }
 resource "azurerm_managed_disk" "data_disk" {

--- a/examples/satellite-azure/variables.tf
+++ b/examples/satellite-azure/variables.tf
@@ -142,6 +142,17 @@ variable "addl_hosts" {
   }
 }
 
+variable "worker_image_sku" {
+  description = "Operating system image SKU for the workers created"
+  type = string
+  default = "7-LVM"
+}
+
+variable "worker_image_version" {
+  description = "Operating system image version for the workers created"
+  type = string
+  default = "latest"
+}
 # ##################################################
 # # IBM CLOUD Satellite Location Variables
 # ##################################################

--- a/examples/satellite-azure/variables.tf
+++ b/examples/satellite-azure/variables.tf
@@ -144,14 +144,14 @@ variable "addl_hosts" {
 
 variable "worker_image_sku" {
   description = "Operating system image SKU for the workers created"
-  type = string
-  default = "7-LVM"
+  type        = string
+  default     = "7-LVM"
 }
 
 variable "worker_image_version" {
   description = "Operating system image version for the workers created"
-  type = string
-  default = "latest"
+  type        = string
+  default     = "latest"
 }
 # ##################################################
 # # IBM CLOUD Satellite Location Variables

--- a/examples/satellite-gcp/README.md
+++ b/examples/satellite-gcp/README.md
@@ -163,6 +163,8 @@ module "satellite-host" {
 | instance_type                         | [Deprecated] The type of google instance to start                  | string   | null             | no    |
 | cp_hosts                              | A list of GCP host objects used to create the location control plane, including parameters instance_type and count. Control plane count values should always be in multipes of 3, such as 3, 6, 9, or 12 hosts.                  | list   | [<br>&ensp; {<br>&ensp;&ensp; instance_type = "n2-standard-4"<br>&ensp; count         = 3<br>&ensp;&ensp; }<br>]             | yes    |
 | addl_hosts                            | A list of GCP host objects used for provisioning services on your location after setup, including instance_type and count, see cp_hosts for an example.                  | list   | []             | yes    |
+| worker_image_family                          | Specify the image family for hosts to be created with                    | string   | rhel-7    | no       |
+| worker_image_project                          | Specify the image project for hosts to be created with                    | string   | rhel-cloud    | no       |
 | ssh_public_key                        | SSH Public Key. Get your ssh key by running `ssh-key-gen` command | string   | n/a     | no |
 | gcp_ssh_user                        | "SSH User of above provided ssh_public_key" | string   | n/a     | no |
 

--- a/examples/satellite-gcp/instance.tf
+++ b/examples/satellite-gcp/instance.tf
@@ -121,8 +121,8 @@ module "gcp_host-template" {
   # startup_script=module.satellite-location.host_script
   machine_type         = each.value.instance_type
   can_ip_forward       = false
-  source_image_project = "rhel-cloud"
-  source_image_family  = "rhel-7"
+  source_image_project = var.worker_image_project
+  source_image_family  = var.worker_image_family
   disk_size_gb         = 100
   disk_type            = "pd-ssd"
   disk_labels = {

--- a/examples/satellite-gcp/variables.tf
+++ b/examples/satellite-gcp/variables.tf
@@ -168,7 +168,16 @@ variable "host_labels" {
     error_message = "Label must be of the form `key:value`."
   }
 }
-
+variable "worker_image_project" {
+  description = "Operating system image project for the workers created"
+  type        = string
+  default     = "rhel-cloud"
+}
+variable "worker_image_family" {
+  description = "Operating system image family for the workers created"
+  type        = string
+  default     = "rhel-7"
+}
 variable "TF_VERSION" {
   description = "Terraform version"
   type        = string

--- a/examples/satellite-ibm/README.md
+++ b/examples/satellite-ibm/README.md
@@ -123,6 +123,7 @@ module "satellite-cluster-worker-pool" {
 | cluster_profile                       | [Deprecated] Profile information of cluster hosts                              | string   | mx2-8x64| no       |
 | cp_hosts                              | A list of IBM host objects used to create the location control plane, including parameters instance_type and count. Control plane count values should always be in multipes of 3, such as 3, 6, 9, or 12 hosts.                  | list   | [<br>&ensp; {<br>&ensp;&ensp; instance_type = "mx2-8x64"<br>&ensp; count         = 3<br>&ensp;&ensp; }<br>]             | no    |
 | addl_hosts                            | A list of IBM host objects used for provisioning services on your location after setup, including instance_type and count, see cp_hosts for an example.                  | list   | []             | no    |
+| worker_image                          | Specify the image for hosts to be created with                    | string   | ibm-redhat-7-9-minimal-amd64-3    | no       |
 | create_cluster                        | Create cluster Disable this, not to provision cluster             | bool     | true    | no       |
 | cluster                               | Name of the ROKS Cluster that has to be created                   | string   | satellite-ibm-cluster     | no      |
 | cluster_zones                         | Allocate your hosts across these three zones                      | set      | n/a     | no      |

--- a/examples/satellite-ibm/instance.tf
+++ b/examples/satellite-ibm/instance.tf
@@ -7,8 +7,8 @@ data "ibm_resource_group" "resource_group" {
   name = var.resource_group
 }
 
-data "ibm_is_image" "rhel7" {
-  name = "ibm-redhat-7-9-minimal-amd64-3"
+data "ibm_is_image" "rhel" {
+  name = var.worker_image
 }
 
 resource "ibm_is_vpc" "satellite_vpc" {
@@ -57,7 +57,7 @@ resource "ibm_is_instance" "ibm_host" {
   name           = "${var.is_prefix}-host-${each.key}"
   vpc            = ibm_is_vpc.satellite_vpc.id
   zone           = element(local.zones, each.key)
-  image          = data.ibm_is_image.rhel7.id
+  image          = data.ibm_is_image.rhel.id
   profile        = each.value.instance_type
   keys           = [var.ssh_key_id != null ? var.ssh_key_id : ibm_is_ssh_key.satellite_ssh[0].id]
   resource_group = data.ibm_resource_group.resource_group.id

--- a/examples/satellite-ibm/variables.tf
+++ b/examples/satellite-ibm/variables.tf
@@ -155,6 +155,11 @@ variable "cluster_profile" {
   default     = "mx2-8x64"
 }
 
+variable "worker_image" {
+  description = "Operating system image for the workers created"
+  type        = string
+  default     = "ibm-redhat-7-9-minimal-amd64-3"
+}
 ##################################################
 # IBMCLOUD ROKS Cluster Variables
 ##################################################


### PR DESCRIPTION
We're going to start allowing people to choose between rhel 7 and 8 when creating hosts because rhel 7 is being deprecated within the next half year.