### PR TITLE
Bump aws ami default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_stages: [commit]
 # Terraform Validate : Validates the configuration files in a directory, referring only to the configuration and not accessing any remote services such as remote state, provider APIs, etc
 repos:
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.72.1
+  rev: v1.75.0
   hooks:
     - id: terraform_fmt
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -20,7 +20,7 @@ repos:
   # You are encouraged to use static refs such as tags, instead of branch name
   #
   # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-  rev: 0.13.1+ibm.50.dss
+  rev: 0.13.1+ibm.52.dss
   hooks:
     - id: detect-secrets # pragma: whitelist secret
       # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-06-16T15:58:00Z",
+  "generated_at": "2022-09-27T14:03:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,7 +77,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.50.dss",
+  "version": "0.13.1+ibm.51.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-09-27T14:07:11Z",
+  "generated_at": "2022-09-27T14:19:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,7 +77,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.50.dss",
+  "version": "0.13.1+ibm.52.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-09-27T14:03:05Z",
+  "generated_at": "2022-09-27T14:07:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,7 +77,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.51.dss",
+  "version": "0.13.1+ibm.50.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/examples/satellite-aws/variables.tf
+++ b/examples/satellite-aws/variables.tf
@@ -192,6 +192,6 @@ variable "resource_prefix" {
 variable "aws_ami" {
   description = "The AMI to use for ec2 instances"
   type        = string
-  default     = "RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2"
+  default     = "RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2"
 }
 


### PR DESCRIPTION
Previous image is deprecated. Amazon removes images after 2 years, so bump it up to one that expires in 2024