### PR TITLE
Dont recalculate pg name every time

### DIFF
--- a/examples/satellite-aws/instance.tf
+++ b/examples/satellite-aws/instance.tf
@@ -73,8 +73,8 @@ module "security_group" {
 }
 
 resource "aws_placement_group" "satellite-group" {
-  name     = "${var.resource_prefix}-pg"
-  strategy = "spread"
+  name         = "${var.resource_prefix}-pg"
+  strategy     = "spread"
   spread_level = "rack"
 
   tags = {

--- a/examples/satellite-aws/instance.tf
+++ b/examples/satellite-aws/instance.tf
@@ -75,6 +75,7 @@ module "security_group" {
 resource "aws_placement_group" "satellite-group" {
   name     = "${var.resource_prefix}-pg"
   strategy = "spread"
+  spread_level = "rack"
 
   tags = {
     ibm-satellite = var.resource_prefix
@@ -110,7 +111,7 @@ module "ec2" {
 
   for_each = local.hosts
 
-  depends_on                  = [module.satellite-location]
+  depends_on                  = [module.satellite-location, aws_placement_group.satellite-group]
   instance_count              = each.value.count
   name                        = "${var.resource_prefix}-host-${each.key}"
   use_num_suffix              = true
@@ -120,7 +121,7 @@ module "ec2" {
   subnet_ids                  = module.vpc.public_subnets
   vpc_security_group_ids      = [module.security_group.this_security_group_id]
   associate_public_ip_address = true
-  placement_group             = aws_placement_group.satellite-group.id
+  placement_group             = "${var.resource_prefix}-pg"
   user_data                   = module.satellite-location.host_script
 
   tags = {


### PR DESCRIPTION
Because `aws_placement_group.satellite_group` is a resource, its id value is recalculated each time causing all hosts to be destroyed and remade. Instead use the pg name which we know as it is equal to the id. The default `spread_level` is also "rack" so put that in so it doesn't recalculate from null -> rack -> null and cause issues as well.

https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/ec2_placement_group.go#L103 for evidence of id being set equal to name. 

Throw the resource as a dependency also into the instance. I tested with changing zones which blocked me (good) as that would have changed the PG, and I also changed the resource prefix which caused everything to be destroyed/remade (also good). 