### PR TITLE
Encode aws user data to base64

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   # You are encouraged to use static refs such as tags, instead of branch name
   #
   # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-  rev: 0.13.1+ibm.53.dss
+  rev: 0.13.1+ibm.55.dss
   hooks:
     - id: detect-secrets # pragma: whitelist secret
       # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-10-18T18:59:44Z",
+  "generated_at": "2022-10-25T21:36:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,7 +77,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.53.dss",
+  "version": "0.13.1+ibm.55.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/examples/satellite-aws/instance.tf
+++ b/examples/satellite-aws/instance.tf
@@ -121,7 +121,7 @@ module "ec2" {
   vpc_security_group_ids      = [module.security_group.this_security_group_id]
   associate_public_ip_address = true
   placement_group             = aws_placement_group.satellite-group.id
-  user_data                   = module.satellite-location.host_script
+  user_data_base64            = base64encode(module.satellite-location.host_script)
 
   tags = {
     ibm-satellite = var.resource_prefix


### PR DESCRIPTION
Right now the user data passed in is around 12KB, max for AWS is 16KB. Switch it over to base64 to prevent issues.

Azure, GCP, and IBM are all covered/have capable room to grow.