### PR TITLE
Bump provider version to support rhel8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ default_stages: [commit]
 # Terraform Validate : Validates the configuration files in a directory, referring only to the configuration and not accessing any remote services such as remote state, provider APIs, etc
 repos:
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.76.0
+  rev: v1.77.0
   hooks:
     - id: terraform_fmt
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.4.0
   hooks:
       - id: check-merge-conflict
       - id: trailing-whitespace
@@ -20,7 +20,7 @@ repos:
   # You are encouraged to use static refs such as tags, instead of branch name
   #
   # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-  rev: 0.13.1+ibm.55.dss
+  rev: 0.13.1+ibm.56.dss
   hooks:
     - id: detect-secrets # pragma: whitelist secret
       # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-10-25T21:36:17Z",
+  "generated_at": "2023-01-04T15:28:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,7 +77,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.55.dss",
+  "version": "0.13.1+ibm.56.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/examples/satellite-aws/versions.tf
+++ b/examples/satellite-aws/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "~> 1.43.0"
+      version = "~> 1.49.0"
     }
   }
 }

--- a/examples/satellite-azure/versions.tf
+++ b/examples/satellite-azure/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "~> 1.43.0"
+      version = "~> 1.49.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/examples/satellite-gcp/versions.tf
+++ b/examples/satellite-gcp/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "~> 1.43.0"
+      version = "~> 1.49.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/examples/satellite-ibm/versions.tf
+++ b/examples/satellite-ibm/versions.tf
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "~> 1.43.0"
+      version = "~> 1.49.0"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
Provider version has bumped and supports rhel8 without unnecessary hacks for python versioning.