### PR TITLE
use gp3 root block device on AWS ec2

### DIFF
--- a/examples/satellite-aws/instance.tf
+++ b/examples/satellite-aws/instance.tf
@@ -123,6 +123,7 @@ module "ec2" {
   associate_public_ip_address = true
   placement_group             = "${var.resource_prefix}-pg"
   user_data_base64            = base64encode(module.satellite-location.host_script)
+  root_block_device           = [{ volume_type = "gp3" }]
 
   tags = {
     ibm-satellite = var.resource_prefix


### PR DESCRIPTION
Update AWS template to use `gp3` ebs volumes for the `root_block_device` of the created ec2 instances. 
gp3 is better and cheaper than gp2:
https://aws.amazon.com/ebs/general-purpose/

Signed-off-by: Edward Fink <finken@us.ibm.com>

