### PR TITLE
chore(actions): update action versions node 16

### DIFF
--- a/.github/workflows/validate_terraform.yml
+++ b/.github/workflows/validate_terraform.yml
@@ -16,10 +16,10 @@ jobs:
           /tmp/tfswitch-install.sh -b $HOME/.bin
       -
         name: checkout                      # action checks-out your repository under $GITHUB_WORKSPACE, so your workflow can access it.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: setup terraform
-        uses: hashicorp/setup-terraform@v1  # sets up Terraform CLI in your GitHub Actions workflow
+        uses: hashicorp/setup-terraform@v2  # sets up Terraform CLI in your GitHub Actions workflow
         with:
           terraform_version: 0.13.1
       -

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_stages: [commit]
 # Terraform Validate : Validates the configuration files in a directory, referring only to the configuration and not accessing any remote services such as remote state, provider APIs, etc
 repos:
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.77.0
+  rev: v1.77.1
   hooks:
     - id: terraform_fmt
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -20,7 +20,7 @@ repos:
   # You are encouraged to use static refs such as tags, instead of branch name
   #
   # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-  rev: 0.13.1+ibm.56.dss
+  rev: 0.13.1+ibm.57.dss
   hooks:
     - id: detect-secrets # pragma: whitelist secret
       # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-01-04T15:28:05Z",
+  "generated_at": "2023-03-28T21:22:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,7 +77,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.56.dss",
+  "version": "0.13.1+ibm.57.dss",
   "word_list": {
     "file": null,
     "hash": null


### PR DESCRIPTION
Update the plugin versions of a couple of our actions to eliminate the node 12 warning messages. 
We should also look into using the common modules actions at some point, but this is a good quick fix in case those node 12 actions stop working. 