### PR TITLE
VMware example: Make gateway optional, update README

### DIFF
--- a/examples/satellite-vmware/README.md
+++ b/examples/satellite-vmware/README.md
@@ -3,27 +3,25 @@ Use this Terraform automation to set up a Satellite location on IBM Cloud with h
 
 This example will:
 - Create an [IBM Cloud Satellite](https://cloud.ibm.com/satellite) location
-- Create Red Hat Core OS VMs in VMware Cloud Director with 3 different specifications: control plane, worker, and storage
+- Create Red Hat CoreOS (RHCOS) VMs in VMware Cloud Director with 3 different specifications: control plane, worker, and storage
 - Attach the VMs to the Satellite location
 - Assign the control plane VMs to the Satellite location control plane
 
-The example has been tested within the [IBM Cloud VMware Shared](https://cloud.ibm.com/docs/vmwaresolutions?topic=vmwaresolutions-shared_overview) environment. Other virtual cloud environments may require further customization. It is heavily based on the [Getting Started with IBM Cloud for VMware Shared Solution tutorial](https://cloud.ibm.com/docs/solution-tutorials?topic=solution-tutorials-vmware-solutions-shared-getting-started).
+The example has been tested within the [IBM Cloud VMware Shared](https://cloud.ibm.com/docs/vmwaresolutions?topic=vmwaresolutions-shared_overview) environment. Other virtual cloud environments may require further customization. It is based on the [Getting Started with IBM Cloud for VMware Shared Solution tutorial](https://cloud.ibm.com/docs/solution-tutorials?topic=solution-tutorials-vmware-solutions-shared-getting-started).
 
 ## Compatibility
 
 This module is meant for use with Terraform 1.1.9 or later.
 
 ## Requirements
-- [Terraform](https://www.terraform.io/downloads.html) 1.1.9 or later.
+- [Terraform](https://www.terraform.io/downloads.html) 1.1.9 or later
 - An IBM Cloud account, with the ability to create Satellite locations
-- IC_API_KEY set in the environment as described in the IBM Terraform provider documentation.
-- A VMware Virtual Cloud environment, with appropriate permissions and access information.
-- Pre-configured networking environment with DHCP enabled.
+- IC_API_KEY set in the environment as described in the [IBM Terraform provider documentation](https://github.com/IBM-Cloud/terraform-provider-ibm/tree/master#download-the-provider-manually-option-2). There are other approaches to configure this including a `providers` file if developing your own terraform based on the example.
+- A VMware Virtual Cloud environment, with appropriate permissions and access information
+- Pre-configured networking environment with DHCP enabled
 
 
 ## Required environment data
-The tables below outline the information to gather from your environment before filling out the terraform variable values.
-
 Required to connect to the VMware Cloud Director environment:
 | Name                                  | Description                                                       | Example
 |---------------------------------------|-------------------------------------------------------------------|--------------|
@@ -45,9 +43,9 @@ vdc_edge_gateway_name | The name of the edge network configured in the environme
 Other input information can be found in [variables.tf](variables.tf).
 
 ## Networking configuration
-This section details what is needed in a [VMware Solutions Shared environment on IBM Cloud](https://cloud.ibm.com/docs/vmwaresolutions?topic=vmwaresolutions-shared_overview) environment. [The Satellite documentation](https://cloud.ibm.com/docs/satellite?topic=satellite-getting-started), can be consulted for more details about what is generally needed.
+This section details what is needed in a [VMware Solutions Shared environment on IBM Cloud](https://cloud.ibm.com/docs/vmwaresolutions?topic=vmwaresolutions-shared_overview) environment. [The Satellite documentation](https://cloud.ibm.com/docs/satellite?topic=satellite-getting-started) can be consulted for more details about what is generally needed when setting up an IBM Cloud Satellite environment.
 
-Before attempting to run the example, the following must be created in the virtual data center:
+Before attempting to run the example, the following **must** be created in the virtual data center:
 - A routed VDC network
 - An edge gateway, configured with **Distributed Routing** enabled. This network should also be **configured with DHCP**. Add a DHCP pool with IP addresses from the previously created VDC network, and **enable DHCP**.
 

--- a/examples/satellite-vmware/README.md
+++ b/examples/satellite-vmware/README.md
@@ -22,7 +22,7 @@ This module is meant for use with Terraform 1.1.9 or later.
 
 
 ## Required environment data
-The tables below outline the information to gather from your environment before filling out the terraform variable values. 
+The tables below outline the information to gather from your environment before filling out the terraform variable values.
 
 Required to connect to the VMware Cloud Director environment:
 | Name                                  | Description                                                       | Example
@@ -41,7 +41,7 @@ Used within the VMware environment when configuring the Virtual Machines and net
 rhcos_template_id     | The ID of the RHCOS 4.12+ template to be used when provisioning the virtual machines      | 158d698b-7498-4038-b48d-70665115f4ea |
 dhcp_network_name     | The name of the network pre-configured for the environment         | my-network |
 vdc_edge_gateway_name | The name of the edge network configured in the environment. This may not be needed in all applications, but if provided, firewall rules and NAT setup will take place | edge-dal10-12345678 |
- 
+
 Other input information can be found in variables.tf TODO: link this
 
 ## Networking configuration

--- a/examples/satellite-vmware/README.md
+++ b/examples/satellite-vmware/README.md
@@ -31,7 +31,9 @@ vcd_user              | The VMware Cloud Director username | admin |
 vcd_password          | The VMware Cloud Director password ||
 vcd_org               | The VMware organization name | 0ff080abcdef123456789abcd12345678 |
 vcd_url               | The VMware Cloud Director URL | `https://daldir01.vmware-solutions.cloud.ibm.com/api` |
-vdc_name              | The VMware Cloud Director virtual datacenter name | vmware-satellite |
+vdc_name              | The VMware Cloud Director virtual data center name | vmware-satellite |
+
+<BR/>
 
 Used within the VMware environment when configuring the Virtual Machines and networking:
 | Name                                  | Description                                                       | Example
@@ -43,20 +45,20 @@ vdc_edge_gateway_name | The name of the edge network configured in the environme
 Other input information can be found in variables.tf TODO: link this
 
 ## Networking configuration
-Networking environments can vary quite a bit. This section details what is needed in the [VMware Solutions Shared environment on IBM Cloud](https://cloud.ibm.com/docs/vmwaresolutions?topic=vmwaresolutions-shared_overview). [The Satellite documentation](https://cloud.ibm.com/docs/satellite?topic=satellite-getting-started), can be consulted for more details about what is generally needed.
+This section details what is needed in a [VMware Solutions Shared environment on IBM Cloud](https://cloud.ibm.com/docs/vmwaresolutions?topic=vmwaresolutions-shared_overview) environment. [The Satellite documentation](https://cloud.ibm.com/docs/satellite?topic=satellite-getting-started), can be consulted for more details about what is generally needed.
 
-Before attempting to run the example, the following must be created:
+Before attempting to run the example, the following must be created in the virtual data center:
 - A routed VDC network
 - An edge gateway, configured with **Distributed Routing** enabled. This network should also be **configured with DHCP**. Add a DHCP pool with IP addresses from the previously created VDC network, and **enable DHCP**.
 
-When running this example, supply the name of the routed VDC network as `dhcp_network_name`. The edge gateway is optionally provided as `vdc_edge_gateway_name`. The following will be configured by the example:
+When running this example, supply the name of the routed VDC network as `dhcp_network_name`. The edge gateway is **optionally** provided as `vdc_edge_gateway_name`. The following will be configured by the example:
 - Virtual machines will use the `dhcp_network_name` network, with IPs from the DHCP pool.
 - If the `vdc_edge_gateway_name` is provided, firewall rules will be created for full outbound connectivity from the VDC network.
 - If the `vdc_edge_gateway_name` is provided, an SNAT rule will be created for mapping to an external IP.
 
 
 ## Compute Details
-This example creates Red Hat CoreOS virtual machines for use with IBM Cloud Satellite. A Red Hat CoreOS v4 image must be available in the VMWare environment.Provide its ID in the variable `rhcos_template_id`.
+This example creates Red Hat CoreOS virtual machines for use with IBM Cloud Satellite. A Red Hat CoreOS v4 image must be available in the VMWare environment. Provide its ID in the variable `rhcos_template_id`.
 
 
 The example will create 3 different sizes of virtual machines:

--- a/examples/satellite-vmware/README.md
+++ b/examples/satellite-vmware/README.md
@@ -7,7 +7,7 @@ This example will:
 - Attach the VMs to the Satellite location
 - Assign the control plane VMs to the Satellite location control plane
 
-The example has been tested within the [IBM Cloud VMware Shared](https://cloud.ibm.com/docs/vmwaresolutions?topic=vmwaresolutions-shared_overview) environment. Other virtual cloud environments may require further customization. It is heavily based on the Getting Started with [IBM Cloud for VMware Shared Solution tutorial](https://cloud.ibm.com/docs/solution-tutorials?topic=solution-tutorials-vmware-solutions-shared-getting-started).
+The example has been tested within the [IBM Cloud VMware Shared](https://cloud.ibm.com/docs/vmwaresolutions?topic=vmwaresolutions-shared_overview) environment. Other virtual cloud environments may require further customization. It is heavily based on the [Getting Started with IBM Cloud for VMware Shared Solution tutorial](https://cloud.ibm.com/docs/solution-tutorials?topic=solution-tutorials-vmware-solutions-shared-getting-started).
 
 ## Compatibility
 
@@ -42,7 +42,7 @@ rhcos_template_id     | The ID of the RHCOS 4.12+ template to be used when provi
 dhcp_network_name     | The name of the network pre-configured for the environment         | my-network |
 vdc_edge_gateway_name | The name of the edge network configured in the environment. This may not be needed in all applications, but if provided, firewall rules and NAT setup will take place | edge-dal10-12345678 |
 
-Other input information can be found in variables.tf TODO: link this
+Other input information can be found in [variables.tf](variables.tf).
 
 ## Networking configuration
 This section details what is needed in a [VMware Solutions Shared environment on IBM Cloud](https://cloud.ibm.com/docs/vmwaresolutions?topic=vmwaresolutions-shared_overview) environment. [The Satellite documentation](https://cloud.ibm.com/docs/satellite?topic=satellite-getting-started), can be consulted for more details about what is generally needed.
@@ -75,4 +75,4 @@ Further details:
 
 
 ## Inputs
-See variables.tf for input information.
+See [variables.tf](variables.tf) for input information.

--- a/examples/satellite-vmware/README.md
+++ b/examples/satellite-vmware/README.md
@@ -56,9 +56,17 @@ When running this example, supply the name of the routed VDC network as `dhcp_ne
 
 
 ## Compute Details
-TODO: fill in
+This example creates Red Hat CoreOS virtual machines for use with IBM Cloud Satellite. A Red Hat CoreOS v4 image must be available in the VMWare environment.Provide its ID in the variable `rhcos_template_id`.
 
 
+The example will create 3 different sizes of virtual machines:
+- Control plane virtual machines (8 CPU, 32GB RAM, 100GB primary disk)
+- Worker virtual machines (4 CPU, 16GB RAM, 25GB primary disk, 100GB secondary disk)
+- Storage virtual machines (16 CPU, 64GB RAM, 25GB primary disk, 100GB secondary disk, 500GB tertiary disk). The specs for the storage VMs are configurable via terraform variables.
+
+These virtual machines will automatically attach to the Satellite location on boot. The control plane virtual machines will automatically be assigned to the location's control plane.
+
+Further details:
 * The `satellite-location` module creates a new location or uses an existing location ID/name. If using an existing location, set `is_location_exist` to `true`.
 * The `satellite-location` module downloads the attach host script to the $HOME directory and appends respective permissions to the script.
 * The `satellite-location` module will update the attach host script and pass it as ignition data to VMware during VM creation

--- a/examples/satellite-vmware/README.md
+++ b/examples/satellite-vmware/README.md
@@ -1,63 +1,68 @@
 # satellite-vmware
-
-**Note: this is currently under development, and not yet fully tested.**
-
-Use this terrafrom automation to set up a Satellite location on IBM Cloud with hosts in VMware Cloud Director.
+Use this Terraform automation to set up a Satellite location on IBM Cloud with hosts in VMware Cloud Director.
 
 This example will:
-- Create the IBM Cloud Satellite location
-- Create RHCOS VMs in VMware Cloud Director with 3 different specifications: control plane, worker, and storage
+- Create an [IBM Cloud Satellite](https://cloud.ibm.com/satellite) location
+- Create Red Hat Core OS VMs in VMware Cloud Director with 3 different specifications: control plane, worker, and storage
 - Attach the VMs to the Satellite location
 - Assign the control plane VMs to the Satellite location control plane
 
+The example has been tested within the [IBM Cloud VMware Shared](https://cloud.ibm.com/docs/vmwaresolutions?topic=vmwaresolutions-shared_overview) environment. Other virtual cloud environments may require further customization. It is heavily based on the Getting Started with [IBM Cloud for VMware Shared Solution tutorial](https://cloud.ibm.com/docs/solution-tutorials?topic=solution-tutorials-vmware-solutions-shared-getting-started).
 
 ## Compatibility
 
-This module is meant for use with Terraform 1.1 or later.
+This module is meant for use with Terraform 1.1.9 or later.
 
 ## Requirements
-
-### Terraform plugins
-
-- [Terraform](https://www.terraform.io/downloads.html) 1.1 or later.
-- [terraform-provider-ibm](https://github.com/IBM-Cloud/terraform-provider-ibm)
-
-## Install
-
-### Terraform provider plugins
-
-Be sure you have the compiled plugins on $HOME/.terraform.d/plugins/
-
-- [terraform-provider-ibm](https://github.com/IBM-Cloud/terraform-provider-ibm)
+- [Terraform](https://www.terraform.io/downloads.html) 1.1.9 or later.
+- An IBM Cloud account, with the ability to create Satellite locations
+- IC_API_KEY set in the environment as described in the IBM Terraform provider documentation.
+- A VMware Virtual Cloud environment, with appropriate permissions and access information.
+- Pre-configured networking environment with DHCP enabled.
 
 
-## Note
+## Required environment data
+The tables below outline the information to gather from your environment before filling out the terraform variable values. 
 
-* `satellite-location` module creates a new location or uses an existing location ID/name to process. If using an existing location, set `is_location_exist` to `true`.
-* `satellite-location` module download attach host script to the $HOME directory and appends respective permissions to the script.
-* `satellite-location` module will update the attach host script pass the ignition data to VMware during VM creation
+Required to connect to the VMware Cloud Director environment:
+| Name                                  | Description                                                       | Example
+|---------------------------------------|-------------------------------------------------------------------|--------------|
+vcd_user              | The VMware Cloud Director username | admin |
+vcd_password          | The VMware Cloud Director password ||
+vcd_org               | The VMware organization name | 0ff080abcdef123456789abcd12345678 |
+vcd_url               | The VMware Cloud Director URL | `https://daldir01.vmware-solutions.cloud.ibm.com/api` |
+vdc_name              | The VMware Cloud Director virtual datacenter name | vmware-satellite |
+
+Used within the VMware environment when configuring the Virtual Machines and networking:
+| Name                                  | Description                                                       | Example
+|---------------------------------------|-------------------------------------------------------------------|--------------|
+rhcos_template_id     | The ID of the RHCOS 4.12+ template to be used when provisioning the virtual machines      | 158d698b-7498-4038-b48d-70665115f4ea |
+dhcp_network_name     | The name of the network pre-configured for the environment         | my-network |
+vdc_edge_gateway_name | The name of the edge network configured in the environment. This may not be needed in all applications, but if provided, firewall rules and NAT setup will take place | edge-dal10-12345678 |
+ 
+Other input information can be found in variables.tf TODO: link this
+
+## Networking configuration
+Networking environments can vary quite a bit. This section details what is needed in the [VMware Solutions Shared environment on IBM Cloud](https://cloud.ibm.com/docs/vmwaresolutions?topic=vmwaresolutions-shared_overview). [The Satellite documentation](https://cloud.ibm.com/docs/satellite?topic=satellite-getting-started), can be consulted for more details about what is generally needed.
+
+Before attempting to run the example, the following must be created:
+- A routed VDC network
+- An edge gateway, configured with **Distributed Routing** enabled. This network should also be **configured with DHCP**. Add a DHCP pool with IP addresses from the previously created VDC network, and **enable DHCP**.
+
+When running this example, supply the name of the routed VDC network as `dhcp_network_name`. The edge gateway is optionally provided as `vdc_edge_gateway_name`. The following will be configured by the example:
+- Virtual machines will use the `dhcp_network_name` network, with IPs from the DHCP pool.
+- If the `vdc_edge_gateway_name` is provided, firewall rules will be created for full outbound connectivity from the VDC network.
+- If the `vdc_edge_gateway_name` is provided, an SNAT rule will be created for mapping to an external IP.
+
+
+## Compute Details
+TODO: fill in
+
+
+* The `satellite-location` module creates a new location or uses an existing location ID/name. If using an existing location, set `is_location_exist` to `true`.
+* The `satellite-location` module downloads the attach host script to the $HOME directory and appends respective permissions to the script.
+* The `satellite-location` module will update the attach host script and pass it as ignition data to VMware during VM creation
 
 
 ## Inputs
-
-| Name                                  | Description                                                       | Type     | Default | Required |
-|---------------------------------------|-------------------------------------------------------------------|----------|---------|----------|
-<!-- | ibmcloud_api_key                      | IBM Cloud API Key                                                 | string   | n/a     | yes      |
-| resource_group                        | Resource group name that has to be targeted                       | string   | n/a     | no       |
-| aws_access_key                        | AWS access key                                                    | string   | n/a     | yes      |
-| aws_secret_key                        | AWS secret key                                                    | string   | n/a     | yes      |
-| aws_region                            | AWS cloud region                                                  | string   | us-east-1  | yes   |
-| location                              | Name of the Location that has to be created                       | string   | satellite-aws  | yes   |
-| is_location_exist                     | Determines if the location has to be created or not               | bool     | false   | yes      |
-| managed_from                          | The IBM Cloud region to manage your Satellite location from.      | string   | wdc     | yes      |
-| location_zones                        | Allocate your hosts across three zones for higher availablity     | list     | []      | no       |
-| labels                                | Add labels to attach host script                                  | list     | [env:prod]  | no   |
-| location_bucket                       | COS bucket name                                                   | string   | n/a     | no       |
-| host_provider                         | The cloud provider of host/vms.                                   | string   | aws     | no       |
-| satellite_host_count                  | [Deprecated] The total number of aws host to create for control plane. satellite_host_count value should always be in multiples of 3, such as 3, 6, 9, or 12 hosts   | number   | 3 |  yes     |
-| addl_host_count                       | [Deprecated] The total number of additional aws host                            | number   | 0 |  yes     |
-| instance_type                         | [Deprecated] The type of aws instance to create.     | string   | m5d.xlarge     | yes |
-| cp_hosts                              | A list of AWS host objects used to create the location control plane, including parameters instance_type and count. Control plane count values should always be in multipes of 3, such as 3, 6, 9, or 12 hosts.                  | list   | [<br>&ensp; {<br>&ensp;&ensp; instance_type = "m5d.xlarge"<br>&ensp; count         = 3<br>&ensp;&ensp; }<br>]             | yes    |
-| addl_hosts                            | A list of AWS host objects used for provisioning services on your location after setup, including instance_type and count, see cp_hosts for an example.                  | list   | []             | yes    |
-| ssh_public_key                        | SSH Public Key. Get your ssh key by running `ssh-key-gen` command | string   | n/a     | no |
-| resource_prefix                       | Name to be used on all aws resources as prefix                        | string   | satellite-aws     | yes | -->
+See variables.tf for input information.

--- a/examples/satellite-vmware/main.tf
+++ b/examples/satellite-vmware/main.tf
@@ -35,15 +35,15 @@ module "satellite-location" {
 
 # Used to obtain information from the already deployed Edge Gateway and network
 module "ibm_vmware_solutions_shared_instance" {
-  source = "./modules/ibm-vmware-solutions-shared-instance/"
-  count = var.vdc_edge_gateway_name != null ? 1 : 0
+  source                = "./modules/ibm-vmware-solutions-shared-instance/"
+  count                 = var.vdc_edge_gateway_name != null ? 1 : 0
   vdc_edge_gateway_name = var.vdc_edge_gateway_name
   network_name          = var.dhcp_network_name
 }
 
 # Create the firewall rule to access the Internet
 resource "vcd_nsxv_firewall_rule" "rule_internet" {
-  count = var.vdc_edge_gateway_name != null ? 1 : 0
+  count        = var.vdc_edge_gateway_name != null ? 1 : 0
   edge_gateway = module.ibm_vmware_solutions_shared_instance[0].edge_gateway_name
   name         = "${var.dhcp_network_name}-Internet"
 
@@ -64,7 +64,7 @@ resource "vcd_nsxv_firewall_rule" "rule_internet" {
 
 # Create SNAT rule to access the Internet
 resource "vcd_nsxv_snat" "rule_internet" {
-  count = var.vdc_edge_gateway_name != null ? 1 : 0
+  count        = var.vdc_edge_gateway_name != null ? 1 : 0
   edge_gateway = module.ibm_vmware_solutions_shared_instance[0].edge_gateway_name
   network_type = "ext"
   network_name = module.ibm_vmware_solutions_shared_instance[0].external_network_name_2
@@ -98,7 +98,7 @@ resource "vcd_nsxv_firewall_rule" "rule_internet_ssh" {
 
 # Create the firewall to access IBM Cloud services over the IBM Cloud private network
 resource "vcd_nsxv_firewall_rule" "rule_ibm_private" {
-  count = var.vdc_edge_gateway_name != null ? 1 : 0
+  count        = var.vdc_edge_gateway_name != null ? 1 : 0
   edge_gateway = module.ibm_vmware_solutions_shared_instance[0].edge_gateway_name
   name         = "${var.dhcp_network_name}-IBM-Private"
 
@@ -120,7 +120,7 @@ resource "vcd_nsxv_firewall_rule" "rule_ibm_private" {
 
 # Create SNAT rule to access the IBM Cloud services over a private network
 resource "vcd_nsxv_snat" "rule_ibm_private" {
-  count = var.vdc_edge_gateway_name != null ? 1 : 0
+  count        = var.vdc_edge_gateway_name != null ? 1 : 0
   edge_gateway = module.ibm_vmware_solutions_shared_instance[0].edge_gateway_name
   network_type = "ext"
   network_name = module.ibm_vmware_solutions_shared_instance[0].external_network_name_1

--- a/examples/satellite-vmware/main.tf
+++ b/examples/satellite-vmware/main.tf
@@ -36,14 +36,15 @@ module "satellite-location" {
 # Used to obtain information from the already deployed Edge Gateway and network
 module "ibm_vmware_solutions_shared_instance" {
   source = "./modules/ibm-vmware-solutions-shared-instance/"
-
+  count = var.vdc_edge_gateway_name != null ? 1 : 0
   vdc_edge_gateway_name = var.vdc_edge_gateway_name
   network_name          = var.dhcp_network_name
 }
 
 # Create the firewall rule to access the Internet
 resource "vcd_nsxv_firewall_rule" "rule_internet" {
-  edge_gateway = module.ibm_vmware_solutions_shared_instance.edge_gateway_name
+  count = var.vdc_edge_gateway_name != null ? 1 : 0
+  edge_gateway = module.ibm_vmware_solutions_shared_instance[0].edge_gateway_name
   name         = "${var.dhcp_network_name}-Internet"
 
   action = "accept"
@@ -63,19 +64,20 @@ resource "vcd_nsxv_firewall_rule" "rule_internet" {
 
 # Create SNAT rule to access the Internet
 resource "vcd_nsxv_snat" "rule_internet" {
-  edge_gateway = module.ibm_vmware_solutions_shared_instance.edge_gateway_name
+  count = var.vdc_edge_gateway_name != null ? 1 : 0
+  edge_gateway = module.ibm_vmware_solutions_shared_instance[0].edge_gateway_name
   network_type = "ext"
-  network_name = module.ibm_vmware_solutions_shared_instance.external_network_name_2
+  network_name = module.ibm_vmware_solutions_shared_instance[0].external_network_name_2
 
-  original_address   = "${module.ibm_vmware_solutions_shared_instance.network_gateway}/24"
-  translated_address = module.ibm_vmware_solutions_shared_instance.default_external_network_ip
+  original_address   = "${module.ibm_vmware_solutions_shared_instance[0].network_gateway}/24"
+  translated_address = module.ibm_vmware_solutions_shared_instance[0].default_external_network_ip
 }
 
 # Create the firewall rule to allow SSH from the Internet
 resource "vcd_nsxv_firewall_rule" "rule_internet_ssh" {
-  count = tobool(var.allow_ssh) == true ? 1 : 0
+  count = tobool(var.allow_ssh) == true && var.vdc_edge_gateway_name != null ? 1 : 0
 
-  edge_gateway = module.ibm_vmware_solutions_shared_instance.edge_gateway_name
+  edge_gateway = module.ibm_vmware_solutions_shared_instance[0].edge_gateway_name
   name         = "${var.dhcp_network_name}-Internet-SSH"
 
   action = "accept"
@@ -85,7 +87,7 @@ resource "vcd_nsxv_firewall_rule" "rule_internet_ssh" {
   }
 
   destination {
-    ip_addresses = [module.ibm_vmware_solutions_shared_instance.default_external_network_ip]
+    ip_addresses = [module.ibm_vmware_solutions_shared_instance[0].default_external_network_ip]
   }
 
   service {
@@ -96,7 +98,8 @@ resource "vcd_nsxv_firewall_rule" "rule_internet_ssh" {
 
 # Create the firewall to access IBM Cloud services over the IBM Cloud private network
 resource "vcd_nsxv_firewall_rule" "rule_ibm_private" {
-  edge_gateway = module.ibm_vmware_solutions_shared_instance.edge_gateway_name
+  count = var.vdc_edge_gateway_name != null ? 1 : 0
+  edge_gateway = module.ibm_vmware_solutions_shared_instance[0].edge_gateway_name
   name         = "${var.dhcp_network_name}-IBM-Private"
 
   logging_enabled = "false"
@@ -107,7 +110,7 @@ resource "vcd_nsxv_firewall_rule" "rule_ibm_private" {
   }
 
   destination {
-    gateway_interfaces = [module.ibm_vmware_solutions_shared_instance.external_network_name_1]
+    gateway_interfaces = [module.ibm_vmware_solutions_shared_instance[0].external_network_name_1]
   }
 
   service {
@@ -117,12 +120,13 @@ resource "vcd_nsxv_firewall_rule" "rule_ibm_private" {
 
 # Create SNAT rule to access the IBM Cloud services over a private network
 resource "vcd_nsxv_snat" "rule_ibm_private" {
-  edge_gateway = module.ibm_vmware_solutions_shared_instance.edge_gateway_name
+  count = var.vdc_edge_gateway_name != null ? 1 : 0
+  edge_gateway = module.ibm_vmware_solutions_shared_instance[0].edge_gateway_name
   network_type = "ext"
-  network_name = module.ibm_vmware_solutions_shared_instance.external_network_name_1
+  network_name = module.ibm_vmware_solutions_shared_instance[0].external_network_name_1
 
-  original_address   = "${module.ibm_vmware_solutions_shared_instance.network_gateway}/24"
-  translated_address = module.ibm_vmware_solutions_shared_instance.external_network_ips_2
+  original_address   = "${module.ibm_vmware_solutions_shared_instance[0].network_gateway}/24"
+  translated_address = module.ibm_vmware_solutions_shared_instance[0].external_network_ips_2
 }
 
 # Create vcd App

--- a/examples/satellite-vmware/variables.tf
+++ b/examples/satellite-vmware/variables.tf
@@ -3,17 +3,17 @@
 ###########################################################
 variable "vcd_user" {
   description = "vCloud Director username"
-  default     = "admin"
+  type        = string
 }
 
 variable "vcd_password" {
   description = "vCloud Director instance password"
-  default     = ""
+  type        = string
 }
 
 variable "vcd_org" {
   description = "vCloud Director organization name/id"
-  default     = ""
+  type        = string
 }
 
 variable "vcd_url" {
@@ -23,7 +23,7 @@ variable "vcd_url" {
 
 variable "vdc_name" {
   description = "vCloud Director virtual datacenter"
-  default     = ""
+  type        = string
 }
 
 variable "vdc_edge_gateway_name" {
@@ -57,7 +57,7 @@ variable "location" {
 }
 
 variable "is_location_exist" {
-  description = "Determines if the location has to be created or not"
+  description = "Determines if the location already exists, or should be created by terraform"
   type        = bool
   default     = false
 }
@@ -74,7 +74,7 @@ variable "location_zones" {
 }
 
 variable "host_labels" {
-  description = "Optional host labels for Satellite. Can be used to direct hosts to different assignments."
+  description = "Optional host labels for Satellite. Can be used to direct hosts to different worker pools."
   type        = list(string)
   default     = []
 }
@@ -95,8 +95,8 @@ variable "vapp_name" {
 }
 
 variable "allow_ssh" {
-  description = "Set to false to not configure SSH into the VM."
-  default     = true
+  description = "Set to true to configure an SSH firewall rule. Will most likely still require manual configuration for NAT."
+  default     = false
 }
 
 variable "ssh_public_key" {

--- a/examples/satellite-vmware/variables.tf
+++ b/examples/satellite-vmware/variables.tf
@@ -28,7 +28,8 @@ variable "vdc_name" {
 
 variable "vdc_edge_gateway_name" {
   description = "vCloud Director virtual datacenter edge gateway name"
-  default     = ""
+  type        = string
+  default     = null
 }
 
 variable "dhcp_network_name" {

--- a/examples/satellite-vmware/versions.tf
+++ b/examples/satellite-vmware/versions.tf
@@ -1,6 +1,11 @@
 terraform {
   required_version = ">= 1.1.9"
   required_providers {
+    ibm = {
+      source  = "IBM-Cloud/ibm"
+      version = "~> 1.59.0"
+    }
+
     vcd = {
       source  = "vmware/vcd"
       version = ">= 3.10.0"


### PR DESCRIPTION
Updates to the VMware example only:
- Specify a required version for the ibm terraform provider.
- Make gateway optional. If it's not provided, user will need to manually configure firewall and NAT. This will allow for more flexibility since networking environments vary quite a bit.
- Update README
- Update some descriptions in `variables.tf`
- Remove some defaults in `variables.tf`. Those values are required, so they shouldn't be defaulted to empty strings.