### PR TITLE
fix(vmware example): bump provider version 1.64.0

### DIFF
--- a/examples/satellite-vmware/versions.tf
+++ b/examples/satellite-vmware/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "~> 1.59.0"
+      version = "~> 1.64.0"
     }
 
     vcd = {


### PR DESCRIPTION
[previous PR](https://github.com/terraform-ibm-modules/terraform-ibm-satellite/pull/89) didn't bump this example, but some of our ci [_sometimes_](https://github.com/terraform-ibm-modules/terraform-ibm-satellite/actions/runs/9290163732) got upset. 

