### PR TITLE
fix(examples): don't point to registry for modules

### DIFF
--- a/examples/satellite-azure/cluster.tf
+++ b/examples/satellite-azure/cluster.tf
@@ -7,7 +7,9 @@
 # Create satellite ROKS cluster
 ###################################################################
 module "satellite-cluster" {
-  source = "terraform-ibm-modules/satellite/ibm//modules/cluster"
+  // source = "terraform-ibm-modules/satellite/ibm//modules/cluster"
+
+  source = "../../modules/cluster"
 
   depends_on                 = [module.satellite-host]
   create_cluster             = var.create_cluster
@@ -29,7 +31,9 @@ module "satellite-cluster" {
 # Create worker pool on existing ROKS cluster
 ###################################################################
 module "satellite-cluster-worker-pool" {
-  source = "terraform-ibm-modules/satellite/ibm//modules/configure-cluster-worker-pool"
+  // source = "terraform-ibm-modules/satellite/ibm//modules/configure-cluster-worker-pool"
+
+  source = "../../modules/configure-cluster-worker-pool"
 
   depends_on                 = [module.satellite-cluster]
   create_cluster_worker_pool = var.create_cluster_worker_pool

--- a/examples/satellite-vmware/main.tf
+++ b/examples/satellite-vmware/main.tf
@@ -22,7 +22,9 @@ locals {
 }
 
 module "satellite-location" {
-  source            = "terraform-ibm-modules/satellite/ibm//modules/location"
+  // source            = "terraform-ibm-modules/satellite/ibm//modules/location"
+  source = "../../modules/location"
+
   is_location_exist = var.is_location_exist
   coreos_enabled    = true
   coreos_host       = true
@@ -269,7 +271,8 @@ resource "vcd_vm_internal_disk" "storage_disks_2" {
 
 # Assign control plane hosts to control plane
 module "satellite-host" {
-  source         = "terraform-ibm-modules/satellite/ibm//modules/host"
+  // source         = "terraform-ibm-modules/satellite/ibm//modules/host"
+  source         = "../../modules/host"
   host_count     = var.num_control_plane_hosts
   location       = module.satellite-location.location_id
   host_vms       = [for v in vcd_vapp_vm.control_plane_vms : v.name]


### PR DESCRIPTION
Because we package up the examples, we need to make sure they're pointing to the module code that they're built with. Most of them are, but a few of these were still pointing to the registry. 