### PR TITLE
feat: add ssh security group option to IBM example

### DIFF
--- a/examples/satellite-ibm/README.md
+++ b/examples/satellite-ibm/README.md
@@ -164,7 +164,7 @@ calico_ip_autodetection = {
 |---------------------------------------|-------------------------------------------------------------------|----------|---------|----------|
 | resource_group                        | Resource Group Name that has to be targeted.                      | string   | n/a     | yes      |
 | ibm_region                            | The location or the region in which VM instance exists.           | string   | us-east | no       |
-| location                              | Name of the Location that has to be created                       | string   | n/a     | satellite-ibm|
+| location                              | Name of location to be created. Can also be ID of existing location. if `is_location_exist` is true | string   | satellite-ibm     | no |
 | is_location_exist                     | Determines if the location has to be created or not               | bool     | false   | no       |
 | managed_from                          | The IBM Cloud region to manage your Satellite location from.      | string   | wdc     | no       |
 | location_zones                        | Allocate your hosts across three zones for higher availablity     | list     | ["us-east-1", "us-east-2", "us-east-3"]     | no  |
@@ -196,6 +196,7 @@ calico_ip_autodetection = {
 | pod_subnet                            | Custom subnet CIDR to provide private IP addresses for pods       | string   | null    | no       |
 | service_subnet                        | Custom subnet CIDR to provide private IP addresses for services   | string   | null    | no       |
 | calico_ip_autodetection               | Set IP autodetection to use correct interface for Calico (needs RHCOS) | map(string) | null | no       |
+| allow_ssh_sg                          | Include an allow rule for SSH during security group creation      | bool     | true  | no         |
 
 
 

--- a/examples/satellite-ibm/README.md
+++ b/examples/satellite-ibm/README.md
@@ -164,7 +164,7 @@ calico_ip_autodetection = {
 |---------------------------------------|-------------------------------------------------------------------|----------|---------|----------|
 | resource_group                        | Resource Group Name that has to be targeted.                      | string   | n/a     | yes      |
 | ibm_region                            | The location or the region in which VM instance exists.           | string   | us-east | no       |
-| location                              | Name of location to be created. Can also be ID of existing location. if `is_location_exist` is true | string   | satellite-ibm     | no |
+| location                              | Name of location to be created. Can also be ID of existing location if `is_location_exist` is true | string   | satellite-ibm     | no |
 | is_location_exist                     | Determines if the location has to be created or not               | bool     | false   | no       |
 | managed_from                          | The IBM Cloud region to manage your Satellite location from.      | string   | wdc     | no       |
 | location_zones                        | Allocate your hosts across three zones for higher availablity     | list     | ["us-east-1", "us-east-2", "us-east-3"]     | no  |

--- a/examples/satellite-ibm/locals.tf
+++ b/examples/satellite-ibm/locals.tf
@@ -11,11 +11,12 @@ locals {
       icmp       = lookup(r, "icmp", null)
       tcp        = lookup(r, "tcp", null)
       udp        = lookup(r, "udp", null)
-    }
+    } if r.service != "ssh" || var.allow_ssh_sg == true
   ]
   rules = [
     {
       name      = "${var.is_prefix}-ingress-1"
+      service   = "ssh"
       direction = "inbound"
       remote    = "0.0.0.0/0"
       tcp = {
@@ -25,6 +26,7 @@ locals {
     },
     {
       name      = "${var.is_prefix}-ingress-2"
+      service   = "http"
       direction = "inbound"
       remote    = "0.0.0.0/0"
       tcp = {
@@ -34,6 +36,7 @@ locals {
     },
     {
       name      = "${var.is_prefix}-ingress-3"
+      service   = "https"
       direction = "inbound"
       remote    = "0.0.0.0/0"
       tcp = {
@@ -43,6 +46,7 @@ locals {
     },
     {
       name      = "${var.is_prefix}-ingress-4"
+      service   = "openshift"
       direction = "inbound"
       remote    = "0.0.0.0/0"
       tcp = {
@@ -52,6 +56,7 @@ locals {
     },
     {
       name      = "${var.is_prefix}-ingress-5"
+      service   = "openshift"
       direction = "inbound"
       remote    = "0.0.0.0/0"
       udp = {
@@ -61,6 +66,7 @@ locals {
     },
     {
       name      = "${var.is_prefix}-ingress-6"
+      service   = ""
       direction = "inbound"
       icmp = {
         type = 8
@@ -69,6 +75,7 @@ locals {
     },
     {
       name      = "${var.is_prefix}-egress-1"
+      service   = ""
       direction = "outbound"
       remote    = "0.0.0.0/0"
       tcp = {

--- a/examples/satellite-ibm/variables.tf
+++ b/examples/satellite-ibm/variables.tf
@@ -83,6 +83,15 @@ variable "service_subnet" {
 }
 
 ##################################################
+# IBMCLOUD VPC Security Group Variables
+##################################################
+variable "allow_ssh_sg" {
+  description = "Include an allow rule for SSH during security group creation"
+  type        = bool
+  default     = true
+}
+
+##################################################
 # IBMCLOUD VPC VSI Variables
 ##################################################
 variable "host_count" {


### PR DESCRIPTION
Add an ssh security group option to the ibm cloud example. 
No change to the default behavior, but we can send false so that the SG isn't open to external SSH. 
