### PR TITLE
feat(ibm example): allow two different images

### DIFF
--- a/examples/satellite-ibm/variables.tf
+++ b/examples/satellite-ibm/variables.tf
@@ -194,6 +194,12 @@ variable "worker_image" {
   default     = "ibm-redhat-8-6-minimal-amd64-1"
 }
 
+variable "control_plane_image" {
+  description = "Operating system image for the control plane workers created. Only needed if different image is desired."
+  type        = string
+  default     = null
+}
+
 
 variable "worker_image_custom_id" {
   description = "Operating system image for the workers created, custom image by ID. If supplied, this will override worker_image above."

--- a/examples/satellite-ibm/variables.tf
+++ b/examples/satellite-ibm/variables.tf
@@ -195,7 +195,7 @@ variable "worker_image" {
 }
 
 variable "control_plane_image" {
-  description = "Operating system image for the control plane workers created. Only needed if different image is desired."
+  description = "Operating system image for the control plane workers created. If supplied, this will override worker_image above for cp nodes."
   type        = string
   default     = null
 }


### PR DESCRIPTION
Allow two different images in the IBM Cloud VPC example. Since RHEL9 can't be used for control plane nodes yet, this allows us to specify RHEL8 for control plane and RHEL9 for additional nodes. 
